### PR TITLE
Updated blackfire/php-sdk dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=8.0",
-        "blackfire/php-sdk": "^1.16",
+        "blackfire/php-sdk": ">=1.16",
         "upscale/ext-swoole": "^4.0||^5.0",
         "upscale/ext-openswoole": "^4.0",
         "upscale/swoole-reflection": "^2.0||^3.0"


### PR DESCRIPTION
This PR makes it possible to install `upscalesoftware/swoole-blackfire` when `blackfire/php-sdk ^2.*` is used. So it fixes the following error:
```
...
Problem 1
    - Root composer.json requires upscale/swoole-blackfire ^4.0.0 -> satisfiable by upscale/swoole-blackfire[4.0.0].
    - upscale/swoole-blackfire 4.0.0 requires blackfire/php-sdk ^1.16 -> found blackfire/php-sdk[v1.16.0, ..., v1.35.0] but it conflicts with your root composer.json require (^2.0).
...
```